### PR TITLE
Android.bp: fix typo of libvsomeip dependency

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -23,7 +23,7 @@ cc_library_shared {
     ],
     shared_libs: [
 	"libCommonAPI",
-	"libvsomeip"
+	"libvsomeip3"
     ],
     rtti: true
 }


### PR DESCRIPTION
fix typo of libvsomeip [1]

[1] https://github.com/GENIVI/vsomeip/blob/master/Android.bp#L47