### PR TITLE
Outputstream: Fix endianness issues when writing array lengths

### DIFF
--- a/include/CommonAPI/SomeIP/OutputStream.hpp
+++ b/include/CommonAPI/SomeIP/OutputStream.hpp
@@ -567,15 +567,29 @@ public:
             } value;
             value.typed = _value;
     #if __BYTE_ORDER == __LITTLE_ENDIAN
-            byte_t reordered[sizeof(Type_)];
-            byte_t *source = &value.raw[sizeof(Type_)-1];
-            byte_t *target = reordered;
-            for (size_t i = 0; i < sizeof(Type_); ++i) {
-                *target++ = *source--;
+            if (isLittleEndian_) {
+                _writeRawAt(value.raw, sizeof(Type_), _position);
+            } else {
+                byte_t reordered[sizeof(Type_)];
+                byte_t *source = &value.raw[sizeof(Type_) - 1];
+                byte_t *target = reordered;
+                for (size_t i = 0; i < sizeof(Type_); ++i) {
+                    *target++ = *source--;
+                }
+                _writeRawAt(reordered, sizeof(Type_), _position);
             }
-            _writeRawAt(reordered, sizeof(Type_), _position);
     #else
-            _writeRawAt(value.raw, sizeof(Type_), _position);
+            if (isLittleEndian_) {
+                byte_t reordered[sizeof(Type_)];
+                byte_t *source = &value.raw[sizeof(Type_) - 1];
+                byte_t *target = reordered;
+                for (size_t i = 0; i < sizeof(Type_); ++i) {
+                    *target++ = *source--;
+                }
+                _writeRawAt(reordered, sizeof(Type_), _position);
+            } else {
+                _writeRawAt(value.raw, sizeof(Type_), _position);
+            }
     #endif
         } else {
             COMMONAPI_ERROR("SomeIP::OutputStream::_writeValueAt payload too small ",


### PR DESCRIPTION
When writing a 2 or 4 byte array length (configured by arrayLengthWidth),
the 16 or 32bit unsigned integer is always written as / converted
to (depending on the endianness of the machine) big endian.
According to the someip spec, the payload's endianness is configurable,
and in the case of little endian, the serializer wrongly assumes
big endian as the payloads endianness.

This causes the deserializer to read the bytes specifying the length of
an array in the wrong byte order, if the payload is little endian,
leading to an error on the consuming side (code is REMOTE_ERROR and not
easy to track).

The program was tested solely for our own use cases, which might differ from yours.

<sub>Mark Schmitt [mark.schmitt@daimler.com](mailto:mark.schmitt@daimler.com), Daimler TSS GmbH, [imprint](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)</sub>