### PR TITLE
Fix compilation for cppyy-windows

### DIFF
--- a/include/CommonAPI/SomeIP/InputStream.hpp
+++ b/include/CommonAPI/SomeIP/InputStream.hpp
@@ -491,7 +491,7 @@ public:
      * @param message the #Message from which data should be read.
      */
     COMMONAPI_EXPORT InputStream(const Message &_message, bool _isLittleEndian);
-    COMMONAPI_EXPORT InputStream(const InputStream &_stream) = delete;
+    InputStream(const InputStream &_stream) = delete;
 
     /**
      * Destructor; does not call the destructor of the referred #Message. Make sure to maintain a reference to the

--- a/include/CommonAPI/SomeIP/Proxy.hpp
+++ b/include/CommonAPI/SomeIP/Proxy.hpp
@@ -71,7 +71,7 @@ public:
     COMMONAPI_EXPORT virtual const Address &getSomeIpAlias() const;
 
 private:
-    COMMONAPI_EXPORT Proxy(const Proxy&) = delete;
+    Proxy(const Proxy&) = delete;
 
     COMMONAPI_EXPORT void onServiceInstanceStatus(std::shared_ptr<Proxy> _proxy,
                                                          uint16_t serviceId,


### PR DESCRIPTION
Remove dllexport of deleted methods (clang_cl complains)