### PR TITLE
Revert setting the default width of a serialized enumeration

### DIFF
--- a/include/CommonAPI/SomeIP/OutputStream.hpp
+++ b/include/CommonAPI/SomeIP/OutputStream.hpp
@@ -149,9 +149,7 @@ public:
                  break;
              }
          } else {
-             // Default enumeration width is 1 Byte
-             uint8_t value = static_cast<uint8_t>(_value);
-             writeValue(value, static_cast<EmptyDeployment *>(nullptr));
+             writeValue(_value.value_, static_cast<EmptyDeployment *>(nullptr));
          }
          return (*this);
     }


### PR DESCRIPTION
# Description of change

Setting the enum `width` as this code did narrows the enumeration value when it has a non-default width and a deployable object is unused.

_e.g._ That `static_cast` narrows the value of the enumeration regardless what its actual literal type is.  This causes serialization to fail.

I first reported this in https://github.com/COVESA/capicxx-someip-runtime/issues/36

# Background

In https://github.com/COVESA/capicxx-someip-runtime/issues/36 I show the fidl/fdepl used to define an enum with a non-default type, and show that the generated code (by generating with core, someip, then core again, as recommended in https://github.com/COVESA/capicxx-core-tools/issues/32, versions 3.2.14) has the proper enum literal type.  However that line causes the deserialization to fail.

This is due to [this change](https://github.com/COVESA/capicxx-someip-runtime/blame/d346e0f4984e8529148ab859e8db4069140d2eeb/include/CommonAPI/SomeIP/OutputStream.hpp#L152-L154) in `OutputStream.hpp`
```diff
-   writeValue(_value.value_, static_cast<EmptyDeployment *>(nullptr)); 
+   // Default enumeration width is 1 Byte
+   uint8_t value = static_cast<uint8_t>(_value);
+   writeValue(value, static_cast<EmptyDeployment *>(nullptr)); 
```
and was [committed with the comment](https://github.com/COVESA/capicxx-someip-runtime/commit/d346e0f4984e8529148ab859e8db4069140d2eeb):
> Changed the default width of a serialized enumeration from "backing type width" to 1 byte.

# Impact

With this change, my deployment type is still a `uint8_t`, _e.g._ (from https://github.com/COVESA/capicxx-someip-runtime/issues/36)
```cpp
typedef CommonAPI::SomeIP::EnumerationDeployment<uint8_t> ColorDeployment_t;
```

And the `Deployable` is still set to `nullptr` on creation, which is expected behaviour according to https://github.com/COVESA/capicxx-someip-tools/issues/37, though it means we skip the [entire code path that deals with a deployable](https://github.com/COVESA/capicxx-someip-runtime/blob/d346e0f4984e8529148ab859e8db4069140d2eeb/include/CommonAPI/SomeIP/OutputStream.hpp#L128-L150).

But [OutputStream::writeValue(const Enumeration<Base_> &_value)](https://github.com/COVESA/capicxx-someip-runtime/blob/d346e0f4984e8529148ab859e8db4069140d2eeb/include/CommonAPI/SomeIP/OutputStream.hpp#L127C23-L127C80) is able to pass the proper value (as type information is retained) to `writeValue`, which fixes serialization.