### PR TITLE
fix: specify cpp standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ cmake_minimum_required (VERSION 2.8)
 
 project (CommonAPI-SomeIP)
 
+set(CMAKE_CXX_STANDARD 17)
+
 set (CMAKE_VERBOSE_MAKEFILE off)
 
 set (LIBCOMMONAPI_SOMEIP_MAJOR_VERSION 3)


### PR DESCRIPTION
- For msvc2019 cpp standard must be set to cpp 17

Fixes #46 