### PR TITLE
Minor InputStream-class fixes

### DIFF
--- a/include/CommonAPI/SomeIP/InputStream.hpp
+++ b/include/CommonAPI/SomeIP/InputStream.hpp
@@ -542,7 +542,6 @@ public:
     template<typename Type_>
     COMMONAPI_EXPORT bool _readBitValue(Type_ &_value, uint8_t _bits, bool _isSigned) {
         bool isError(false);
-        bool isLittleEndian = static_cast<bool>(buffer_[0]);
 
         union {
             Type_ typed_;
@@ -559,7 +558,7 @@ public:
         } else {
             if (currentBit_ == 0 && _bits == (sizeof(Type_) << 3) && current_ != NULL) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-                if (isLittleEndian) {
+                if (isLittleEndian_) {
                     std::memcpy(value.raw_, current_, sizeof(Type_));
                     current_ += sizeof(Type_);
                 } else {
@@ -569,7 +568,7 @@ public:
                     }
                 }
 #else
-                if (isLittleEndian) {
+                if (isLittleEndian_) {
                     byte_t *target = reinterpret_cast<byte_t *>(&value.raw_[sizeof(Type_)-1]);
                     for (size_t i = 0; i < sizeof(Type_); ++i) {
                         *target-- = *current_++;
@@ -627,11 +626,10 @@ public:
                     }
                 }
 
-// Set the target (TODO: Add isLittleEndian_ member and use it here)
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-                const std::size_t targetIndex = ((sizeof(Type_) == 1) || isLittleEndian) ? 0 : sizeof(Type_) - 1;
+                const std::size_t targetIndex = ((sizeof(Type_) == 1) || isLittleEndian_) ? 0 : sizeof(Type_) - 1;
 #else
-                const std::size_t targetIndex = ((sizeof(Type_) > 1) && isLittleEndian) ? sizeof(Type_) - 1 : 0;
+                const std::size_t targetIndex = ((sizeof(Type_) > 1) && isLittleEndian_) ? sizeof(Type_) - 1 : 0;
 #endif
                 byte_t *target = reinterpret_cast<byte_t *>(&value.raw_[targetIndex]);
 
@@ -677,12 +675,12 @@ public:
                             (*target) |= itsCurrentByte;
                         }
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-                        if (isLittleEndian)
+                        if (isLittleEndian_)
                             target++;
                         else
                             target--;
 #else
-                        if (isLittleEndian)
+                        if (isLittleEndian_)
                             target--;
                         else
                             target++;
@@ -723,7 +721,7 @@ private:
     Message message_;
     bool errorOccurred_;
 
-    std::vector<byte_t> buffer_; // used for handling "Little Endian" messages
+    bool isLittleEndian_; // used for handling "Little Endian" messages
 };
 
 } // namespace SomeIP

--- a/include/CommonAPI/SomeIP/InputStream.hpp
+++ b/include/CommonAPI/SomeIP/InputStream.hpp
@@ -627,19 +627,13 @@ public:
                     }
                 }
 
-                // Set the target (TODO: Add isLittleEndian_ member and use it here)
-                byte_t *target(nullptr);
+// Set the target (TODO: Add isLittleEndian_ member and use it here)
 #if __BYTE_ORDER == __LITTLE_ENDIAN
-                if (isLittleEndian)
-                    target = reinterpret_cast<byte_t *>(&value.raw_[0]);
-                else
-                    target = reinterpret_cast<byte_t *>(&value.raw_[sizeof(Type_) - 1]);
+                const std::size_t targetIndex = ((sizeof(Type_) == 1) || isLittleEndian) ? 0 : sizeof(Type_) - 1;
 #else
-                if (isLittleEndian)
-                    target = reinterpret_cast<byte_t *>(&value.raw_[sizeof(Type_) - 1]);
-                else
-                    target = reinterpret_cast<byte_t *>(&value.raw_[0]);
+                const std::size_t targetIndex = ((sizeof(Type_) > 1) && isLittleEndian) ? sizeof(Type_) - 1 : 0;
 #endif
+                byte_t *target = reinterpret_cast<byte_t *>(&value.raw_[targetIndex]);
 
                 uint8_t writePosition = 0;
                 while (_bits > 0) {

--- a/src/CommonAPI/SomeIP/InputStream.cpp
+++ b/src/CommonAPI/SomeIP/InputStream.cpp
@@ -24,8 +24,9 @@ InputStream::InputStream(const CommonAPI::SomeIP::Message &_message,
       currentBit_(0),
       remaining_(_message.getBodyLength()),
       message_(_message),
-      errorOccurred_(false) {
-    buffer_.push_back(static_cast<byte_t>(_isLittleEndian));
+      errorOccurred_(false),
+      isLittleEndian_(_isLittleEndian)
+{
 }
 
 InputStream::~InputStream() {}

--- a/src/CommonAPI/SomeIP/InputStream.cpp
+++ b/src/CommonAPI/SomeIP/InputStream.cpp
@@ -319,9 +319,7 @@ InputStream& InputStream::readValue(ByteBuffer &_value, const ByteBufferDeployme
     uint32_t byteBufferMaxLength = (_depl ? _depl->byteBufferMaxLength_ : 0xFFFFFFFF);
     uint8_t byteBufferLengthWidth = (_depl ? _depl->byteBufferLengthWidth_ : 4);
 
-    uint32_t itsSize; // this affects how many bytes are read
-    uint32_t maxSize; // this affects how many bytes are stored
-
+    uint32_t itsSize{0}; // this affects how many bytes are read
     // Read array size
     if (byteBufferLengthWidth != 0)
         readValue(itsSize, byteBufferLengthWidth, true);
@@ -331,12 +329,6 @@ InputStream& InputStream::readValue(ByteBuffer &_value, const ByteBufferDeployme
     // Reset target
     _value.clear();
 
-    // check for cutoff
-    if (0 != byteBufferMaxLength && itsSize > byteBufferMaxLength)
-        maxSize = byteBufferMaxLength;
-    else
-        maxSize = itsSize;
-
     if ((byteBufferLengthWidth != 0 && itsSize < byteBufferMinLength)
             || itsSize > remaining_) {
         errorOccurred_ = true;
@@ -345,6 +337,8 @@ InputStream& InputStream::readValue(ByteBuffer &_value, const ByteBufferDeployme
     // Read elements, if reading size has been successful
     if (!hasError()) {
         byte_t *base = _readRaw(itsSize);
+        // check for cutoff, this affects how many bytes are stored
+        const uint32_t maxSize = (0 != byteBufferMaxLength && itsSize > byteBufferMaxLength) ? byteBufferMaxLength : itsSize;
         _value.assign(base, base+maxSize);
     }
 


### PR DESCRIPTION
- fix compiler warning for identical if-branches
```
In instantiation of 'bool CommonAPI::SomeIP::InputStream::_readBitValue(Type_&, uint8_t, bool) [with Type_ = unsigned char; uint8_t = unsigned char]':
[...]
CommonAPI/SomeIP/InputStream.hpp:633:17: warning: this condition has identical branches [-Wduplicated-branches]
  633 |                 if (isLittleEndian)
```

- remove a related TODO statement by adding new class member
- fix uninitialized variable 