### PR TITLE
capicxx-someip-runtime 3.2.4

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -6,13 +6,13 @@ cc_library_shared {
         "-D_GLIBCXX_USE_NANOSLEEP",
         "-DBOOST_LOG_DYN_LINK",
         "-pthread",
-	"-Wno-unused-private-field"
+        "-Wno-unused-private-field",
+        "-Wno-error=deprecated-declarations"
     ],
 
 
     local_include_dirs: [
         "include",
-        "internal",
     ],
 
     shared_libs: [

--- a/Android.mk
+++ b/Android.mk
@@ -34,8 +34,7 @@ LOCAL_SRC_FILES += \
     src/CommonAPI/SomeIP/Watch.cpp \
 
 LOCAL_C_INCLUDES := \
-    $(LOCAL_PATH)/include \
-    $(LOCAL_PATH)/internal
+    $(LOCAL_PATH)/include 
 
 LOCAL_SHARED_LIBRARIES := \
     libboost_log \

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,24 @@
 Changes
 =======
 
+v3.2.4
+- Unlock event processing
+- Fix build on Android
+- Call registerAvailabilityHandler before requestService
+- Fix deadlock issue when unregistering services
+- Added github workflow to build in Ubuntu
+- Fix: install boost
+- Build capicxx-someip-runtime on Windows
+
+v3.2.3-r9
+- Fix Copyright & github link in README
+- Fix MethodStubDispatcher template
+- (dev) Warn about multiple subscriptions
+- Improve the CommonAPI-SomeIP Mainloop logs
+- Fix to check for the entry containing a valid Message obj to avoid nullptr
+- Fix Windows build
+- Call registerAvailabilityHandler before requestService
+
 v3.2.3-r8
 - Changed level logs from warning to info when address_aliasing is activated
 - Fix incorrect timings in logs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set (CMAKE_VERBOSE_MAKEFILE off)
 
 set (LIBCOMMONAPI_SOMEIP_MAJOR_VERSION 3)
 set (LIBCOMMONAPI_SOMEIP_MINOR_VERSION 2)
-set (LIBCOMMONAPI_SOMEIP_PATCH_VERSION 3)
+set (LIBCOMMONAPI_SOMEIP_PATCH_VERSION 4)
 
 message(STATUS "Project name: ${PROJECT_NAME}")
 
@@ -66,7 +66,7 @@ include_directories( ${Boost_INCLUDE_DIR} )
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17 -D_CRT_SECURE_NO_WARNINGS /wd4503")
 link_directories(${Boost_LIBRARY_DIR})
 else()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Wformat -Wformat-security -Wconversion -fexceptions -fstrict-aliasing -fstack-protector -fasynchronous-unwind-tables -fno-omit-frame-pointer -DCOMMONAPI_INTERNAL_COMPILATION -D_GLIBCXX_USE_NANOSLEEP -DBOOST_LOG_DYN_LINK -pthread -fvisibility=hidden")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Wall -Wextra -Wformat -Wformat-security -Wconversion -fexceptions -fstrict-aliasing -fstack-protector -fasynchronous-unwind-tables -fno-omit-frame-pointer -DCOMMONAPI_INTERNAL_COMPILATION -D_GLIBCXX_USE_NANOSLEEP -DBOOST_LOG_DYN_LINK -pthread -fvisibility=hidden")
 endif()
 
 SET(MAX_LOG_LEVEL "DEBUG" CACHE STRING "maximum log level")
@@ -214,3 +214,13 @@ endif()
 ##############################################################################
 # maintainer-clean
 add_custom_target(maintainer-clean COMMAND rm -rf *)
+
+##############################################################################
+# for debug
+if(MAINLOOP_DID_NOT_PROCESS_MESSAGE_MS_THRESHOLD)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMAINLOOP_DID_NOT_PROCESS_MESSAGE_MS_THRESHOLD")
+endif()
+
+if(MAINLOOP_WATCH_ELEMENTS_SLOW_THRESHOLD)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMAINLOOP_WATCH_ELEMENTS_SLOW_THRESHOLD")
+endif()

--- a/include/CommonAPI/SomeIP/OutputStream.hpp
+++ b/include/CommonAPI/SomeIP/OutputStream.hpp
@@ -568,7 +568,7 @@ public:
                 byte_t raw[sizeof(Type_)];
             } value;
             value.typed = _value;
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__ANDROID__)
             if ((__BYTE_ORDER == __LITTLE_ENDIAN) != isLittleEndian_) {
 #else
             if (!isLittleEndian_) {

--- a/include/CommonAPI/SomeIP/StubAdapterHelper.hpp
+++ b/include/CommonAPI/SomeIP/StubAdapterHelper.hpp
@@ -338,7 +338,7 @@ private:
 
         (_stub.get()->*stubFunctor_)(
             itsClientId,
-            std::move(std::get<InArgIndices_>(in))...
+            std::move(std::get<InArgIndices_>(in).getValue())...
         );
 
            return true;
@@ -405,7 +405,7 @@ public:
         {
             std::lock_guard<std::mutex> lock(mutex_);
             auto itsMessage = pending_.find(_call);
-            if (itsMessage != pending_.end()) {
+            if (itsMessage != pending_.end() && itsMessage->second) {
                 Message itsReply = itsMessage->second.createResponseMessage();
                 pending_[_call] = itsReply;
             } else {
@@ -504,7 +504,7 @@ private:
 
         std::lock_guard<std::mutex> lock(mutex_);
         auto reply = pending_.find(_call);
-        if (reply != pending_.end()) {
+        if (reply != pending_.end() && reply->second) {
             if (sizeof...(DeplOutArgs_) > 0) {
                 OutputStream output(reply->second, isLittleEndian_);
                 if (!SerializableArguments<CommonAPI::Deployable<OutArgs_, DeplOutArgs_>...>::serialize(
@@ -600,7 +600,7 @@ public:
         {
             std::lock_guard<std::mutex> lock(this->mutex_);
             auto itsMessage = this->pending_.find(_call);
-            if (itsMessage != this->pending_.end()) {
+            if (itsMessage != this->pending_.end() && itsMessage->second) {
                 // TODO create error response message
                 Message itsReply = itsMessage->second.createResponseMessage();
                 this->pending_[_call] = itsReply;
@@ -689,7 +689,7 @@ private:
 
         std::lock_guard<std::mutex> lock(this->mutex_);
         auto itsReply = this->pending_.find(_call);
-        if (itsReply != this->pending_.end()) {
+        if (itsReply != this->pending_.end() && itsReply->second) {
             if (sizeof...(DeplOutArgs_) > 0) {
                 OutputStream output(itsReply->second, this->isLittleEndian_);
                 if (!SerializableArguments<CommonAPI::Deployable<OutArgs_, DeplOutArgs_>...>::serialize(

--- a/src/CommonAPI/SomeIP/Connection.cpp
+++ b/src/CommonAPI/SomeIP/Connection.cpp
@@ -101,8 +101,9 @@ void Connection::handleProxyReceive(const std::shared_ptr<vsomeip::message> &_me
 
         // We must not hold the lock when calling the handlers!
         for (auto handler : handlers) {
-            if(auto itsHandler = handler.second.lock())
+            if(auto itsHandler = handler.second.lock()) {
                 itsHandler->onEventMessage(Message(_message));
+            }
         }
 
         return;

--- a/src/CommonAPI/SomeIP/InstanceAvailabilityStatusChangedEvent.cpp
+++ b/src/CommonAPI/SomeIP/InstanceAvailabilityStatusChangedEvent.cpp
@@ -19,17 +19,9 @@ InstanceAvailabilityStatusChangedEvent::InstanceAvailabilityStatusChangedEvent(
                 observedInterfaceName_(_interfaceName),
                 observedInterfaceServiceId_ (_serviceId),
                 availabilityHandlerId_(0) {
-    Address wildcardAddress(observedInterfaceServiceId_, vsomeip::ANY_INSTANCE, vsomeip::ANY_MAJOR, vsomeip::ANY_MINOR);
-    proxy_.getConnection()->requestService(wildcardAddress);
 }
 
 InstanceAvailabilityStatusChangedEvent::~InstanceAvailabilityStatusChangedEvent() {
-    Address wildcardAddress(observedInterfaceServiceId_, vsomeip::ANY_INSTANCE,  vsomeip::ANY_MAJOR, vsomeip::ANY_MINOR);
-
-    proxy_.getConnection()->unregisterAvailabilityHandler(
-            wildcardAddress, availabilityHandlerId_);
-
-    proxy_.getConnection()->releaseService(wildcardAddress);
 }
 
 void
@@ -98,13 +90,19 @@ InstanceAvailabilityStatusChangedEvent::onFirstListenerAdded(
     std::weak_ptr<Proxy> itsProxy = proxy_.shared_from_this();
     availabilityHandlerId_ = proxy_.getConnection()->registerAvailabilityHandler(
                                 wildcardAddress, onServiceInstanceStatus, itsProxy, this);
+
+    proxy_.getConnection()->requestService(wildcardAddress);
 }
 
 void
 InstanceAvailabilityStatusChangedEvent::onLastListenerRemoved(
         const Listener &) {
-    // Destruktor of InstanceAvailabilityStatusChangedEvent will remove the availability handler
-    // As its needed anyways even if a user never subscribes on this event
+    Address wildcardAddress(observedInterfaceServiceId_, vsomeip::ANY_INSTANCE,  vsomeip::ANY_MAJOR, vsomeip::ANY_MINOR);
+
+    proxy_.getConnection()->unregisterAvailabilityHandler(
+            wildcardAddress, availabilityHandlerId_);
+
+    proxy_.getConnection()->releaseService(wildcardAddress);
 }
 
 bool

--- a/src/CommonAPI/SomeIP/Proxy.cpp
+++ b/src/CommonAPI/SomeIP/Proxy.cpp
@@ -289,8 +289,6 @@ bool Proxy::init() {
     if (!connection)
         return false;
 
-    connection->requestService(alias_);
-
     std::weak_ptr<Proxy> itsProxy = shared_from_this();
     availabilityHandlerId_ = connection->registerAvailabilityHandler(
                                     alias_,
@@ -303,6 +301,9 @@ bool Proxy::init() {
                                               std::placeholders::_5),
                                     itsProxy,
                                     NULL);
+
+    connection->requestService(alias_);
+
     if (connection->isAvailable(alias_)) {
         std::lock_guard<std::mutex> itsLock(availabilityMutex_);
         availabilityStatus_ = AvailabilityStatus::AVAILABLE;


### PR DESCRIPTION
- Unlock event processing
- Fix build on Android
- Call registerAvailabilityHandler before requestService
- Fix deadlock issue when unregistering services
- Added github workflow to build in Ubuntu
- Fix: install boost
- Build capicxx-someip-runtime on Windows
- Fix Copyright & github link in README
- Fix MethodStubDispatcher template
- (dev) Warn about multiple subscriptions
- Improve the CommonAPI-SomeIP Mainloop logs
- Fix to check for the entry containing a valid Message obj to avoid nullptr
- Fix Windows build